### PR TITLE
FIX plataformatec/devise#4127

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -142,10 +142,14 @@ module Devise
 
       opts[:format] = request_format unless skip_format?
 
-      opts[:script_name] = relative_url_root if relative_url_root?
-
       router_name = Devise.mappings[scope].router_name || Devise.available_router_name
       context = send(router_name)
+
+      if relative_url_root?
+        opts[:script_name] = relative_url_root
+      elsif defined? context.routes
+        opts[:script_name] = context.routes.url_helpers.root_path
+      end
 
       if context.respond_to?(route)
         context.send(route, opts)

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -148,7 +148,8 @@ module Devise
       if relative_url_root?
         opts[:script_name] = relative_url_root
       elsif defined? context.routes
-        opts[:script_name] = context.routes.url_helpers.root_path
+        rootpath = context.routes.url_helpers.root_path
+        opts[:script_name] = rootpath.chomp('/') unless rootpath.length <= 1
       end
 
       if context.respond_to?(route)


### PR DESCRIPTION
I've been able to fix the issue for #4127 (comment) though I'd like some help to create the test.

It's pretty simple: the engine should point to a directory inside the engine, in order to trigger the redirect. Then the test would be:

```ruby
test 'redirect to login page when browsing an internal route without being authenticated' do
    get '/mountable_engine/some_route'
    follow_redirect!
    assert_response :success
    assert_contain 'Rendered content of MyMountableEngine'
end
```

@basiszwo, how can I add to your code an internal route some_route in order to test it?